### PR TITLE
feat: add nix flake and package spec

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773579282,
+        "narHash": "sha256-LWvZj9Bvm1EuoO6zbX4yjZebwnZNfeTbmCJGS7RGQ3Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5a88de74db0e948139be4b46f9a94d64aa11391c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  description =
+    "Klassy - Theming utility for the KDE Plasma desktop environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        package = pkgs.callPackage ./package.nix { };
+      in {
+        packages = {
+          default = package;
+          klassy = package;
+        };
+
+        devShells.default = pkgs.mkShell { inputsFrom = [ package ]; };
+      });
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,56 @@
+{ lib, stdenv, fetchFromGitHub, cmake, kdePackages, }:
+
+stdenv.mkDerivation rec {
+  pname = "klassy";
+  version = "6.5.3";
+
+  src = ./.;
+
+  nativeBuildInputs =
+    [ cmake kdePackages.extra-cmake-modules kdePackages.wrapQtAppsHook ];
+
+  buildInputs = with kdePackages; [
+    qtbase
+    qtdeclarative
+    qtsvg
+    frameworkintegration
+    kcmutils
+    kcolorscheme
+    kconfig
+    kconfigwidgets
+    kcoreaddons
+    kguiaddons
+    ki18n
+    kiconthemes
+    kirigami
+    kservice
+    kwidgetsaddons
+    kwindowsystem
+    kdecoration
+    libplasma
+  ];
+
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    "-DBUILD_QT5=OFF"
+    "-DBUILD_QT6=ON"
+    "-DBUILD_TESTING=OFF"
+    "-DKDE_INSTALL_USE_QT_SYS_PATHS=ON"
+  ];
+
+  meta = {
+    description = "Highly customizable window decoration for KDE Plasma";
+    homepage = "https://github.com/paulmcauley/klassy";
+    license = with lib.licenses; [
+      bsd3
+      cc0
+      gpl2Only
+      gpl2Plus
+      gpl3Only
+      gpl3Plus
+      mit
+    ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Adds a nix flake & package specification. Allows nixos users to install the theme via

```nix
# In inputs
inputs = {
  ...
  klassy = { url = "https://github.com/paulmcauley/klassy"; type = "git"; };
};

# In configuration
environment.systemPackages = with pkgs; [
  ...
  inputs.klassy.packages.${system}.default
];
```

And makes it easy to add to the nix package repo https://github.com/NixOS/nixpkgs in the future.