### PR TITLE
Fix #286 - Add exclude from capture button

### DIFF
--- a/kdecoration/breezebutton.cpp
+++ b/kdecoration/breezebutton.cpp
@@ -134,6 +134,16 @@ Button *Button::create(KDecoration3::DecorationButtonType type, KDecoration3::De
             });
             break;
 
+        case KDecoration3::DecorationButtonType::ExcludeFromCapture:
+            b->setVisible(decoration->settings()->isAlwaysShowExcludeFromCapture() || c->isExcludedFromCapture());
+            QObject::connect(decoration->settings().get(), &KDecoration3::DecorationSettings::alwaysShowExcludeFromCaptureChanged, b, [b, c](bool alwaysShow) {
+                b->setVisible(alwaysShow || c->isExcludedFromCapture());
+            });
+            QObject::connect(c, &KDecoration3::DecoratedWindow::excludeFromCaptureChanged, b, [b, decoration](bool excluded) {
+                b->setVisible(decoration->settings()->isAlwaysShowExcludeFromCapture() || excluded);
+            });
+            break;
+
         default:
             break;
         }
@@ -327,10 +337,7 @@ QColor Button::foregroundColor(const bool getNonAnimatedColor) const
     // return a variant of normal, hover and press colours, depending on state
     if (isPressed()) {
         return foregroundPressActiveStateAnimated(active, getNonAnimatedColor);
-    } else if (isChecked()
-               && (type() == KDecoration3::DecorationButtonType::KeepBelow || type() == KDecoration3::DecorationButtonType::KeepAbove
-                   || type() == KDecoration3::DecorationButtonType::Shade
-                   || (type() == KDecoration3::DecorationButtonType::OnAllDesktops && !m_titlebarTextPinnedInversion))) {
+    } else if (isChecked() && isCheckable()) {
         if (m_d->internalSettings()->buttonStateChecked(active) == InternalSettings::EnumButtonStateChecked::Hover) {
             return foregroundHoverActiveStateAnimated(active, getNonAnimatedColor);
         } else {
@@ -424,10 +431,7 @@ QColor Button::backgroundColor(const bool getNonAnimatedColor) const
     // return a variant of normal, hover and press colours, depending on state
     if (isPressed()) {
         return backgroundPressActiveStateAnimated(active, getNonAnimatedColor);
-    } else if (isChecked()
-               && (type() == KDecoration3::DecorationButtonType::KeepBelow || type() == KDecoration3::DecorationButtonType::KeepAbove
-                   || type() == KDecoration3::DecorationButtonType::Shade
-                   || (type() == KDecoration3::DecorationButtonType::OnAllDesktops && !m_titlebarTextPinnedInversion))) {
+    } else if (isChecked() && isCheckable()) {
         if (m_d->internalSettings()->buttonStateChecked(active) == InternalSettings::EnumButtonStateChecked::Hover) {
             return backgroundHoverActiveStateAnimated(active, getNonAnimatedColor);
         } else {
@@ -520,10 +524,7 @@ QColor Button::outlineColor(const bool getNonAnimatedColor) const
     // return a variant of normal, hover and press colours, depending on state
     if (isPressed()) {
         return outlinePressActiveStateAnimated(active, getNonAnimatedColor);
-    } else if (isChecked()
-               && (type() == KDecoration3::DecorationButtonType::KeepBelow || type() == KDecoration3::DecorationButtonType::KeepAbove
-                   || type() == KDecoration3::DecorationButtonType::Shade
-                   || (type() == KDecoration3::DecorationButtonType::OnAllDesktops && !m_titlebarTextPinnedInversion))) {
+    } else if (isChecked() && isCheckable()) {
         if (m_d->internalSettings()->buttonStateChecked(active) == InternalSettings::EnumButtonStateChecked::Hover) {
             return outlineHoverActiveStateAnimated(active, getNonAnimatedColor);
         } else {
@@ -1177,6 +1178,14 @@ bool Button::isSystemIconAvailable() const
         else
             return true;
     }
+}
+
+bool Button::isCheckable() const
+{
+    return (type() == KDecoration3::DecorationButtonType::KeepBelow || type() == KDecoration3::DecorationButtonType::KeepAbove
+            || type() == KDecoration3::DecorationButtonType::Shade
+            || (type() == KDecoration3::DecorationButtonType::ExcludeFromCapture && m_d->settings()->isAlwaysShowExcludeFromCapture())
+            || (type() == KDecoration3::DecorationButtonType::OnAllDesktops && !m_titlebarTextPinnedInversion));
 }
 
 bool Button::hovered() const // for unison hovering

--- a/kdecoration/breezebutton.h
+++ b/kdecoration/breezebutton.h
@@ -215,6 +215,8 @@ private:
 
     bool isSystemIconAvailable() const;
 
+    bool isCheckable() const;
+
     void setDevicePixelRatio(QPainter *painter);
     void setShouldDrawBoldButtonIcons();
     void setStandardScaledPenWidth();

--- a/kdecoration/breezedecoration.cpp
+++ b/kdecoration/breezedecoration.cpp
@@ -389,6 +389,7 @@ void Decoration::init()
     connect(s.get(), &KDecoration3::DecorationSettings::decorationButtonsLeftChanged, this, &Decoration::updateButtonsGeometryDelayed);
     connect(s.get(), &KDecoration3::DecorationSettings::decorationButtonsRightChanged, this, &Decoration::updateButtonsGeometryDelayed);
     connect(s.get(), &KDecoration3::DecorationSettings::onAllDesktopsAvailableChanged, this, &Decoration::updateButtonsGeometryDelayed);
+    connect(c, &KDecoration3::DecoratedWindow::excludeFromCaptureChanged, this, &Decoration::updateButtonsGeometryDelayed);
 
     // full reconfiguration
     connect(s.get(), &KDecoration3::DecorationSettings::reconfigured, this, &Decoration::reconfigure);

--- a/kdecoration/config/breezeconfigwidget.cpp
+++ b/kdecoration/config/breezeconfigwidget.cpp
@@ -839,6 +839,7 @@ void ConfigWidget::getButtonsOrderFromKwinConfig()
     buttonNames[DecorationButtonType::Maximize] = QChar('A');
     buttonNames[DecorationButtonType::Close] = QChar('X');
     buttonNames[DecorationButtonType::Spacer] = QChar('_');
+    buttonNames[DecorationButtonType::ExcludeFromCapture] = QChar('E');
 
     QString buttonsOnLeft;
     QString buttonsOnRight;

--- a/kdecoration/config/buttoncolors.cpp
+++ b/kdecoration/config/buttoncolors.cpp
@@ -600,13 +600,13 @@ void ButtonColors::loadMain(const bool assignUiValuesOnly)
     for (int i = 0; i < InternalSettings::EnumButtonOverrideColorsActiveButtonType::COUNT; i++) {
         if (decodeOverrideColorsAndLoadTableColumn(
                 m_internalSettings->buttonOverrideColorsActive(i).toUtf8(),
-                static_cast<ConfigWidget *>(m_parent)->m_allCustomizableButtonsOrder.indexOf(static_cast<DecorationButtonType>(i)),
+                static_cast<ConfigWidget *>(m_parent)->m_allCustomizableButtonsOrder.indexOf(buttonTypeFromKcfgColorIndex(i)),
                 true)) {
             m_overrideColorsLoaded.active = true;
         }
         if (decodeOverrideColorsAndLoadTableColumn(
                 m_internalSettings->buttonOverrideColorsInactive(i).toUtf8(),
-                static_cast<ConfigWidget *>(m_parent)->m_allCustomizableButtonsOrder.indexOf(static_cast<DecorationButtonType>(i)),
+                static_cast<ConfigWidget *>(m_parent)->m_allCustomizableButtonsOrder.indexOf(buttonTypeFromKcfgColorIndex(i)),
                 false)) {
             m_overrideColorsLoaded.inactive = true;
         }
@@ -667,12 +667,12 @@ void ButtonColors::save(const bool reloadKwinConfig)
     for (int i = 0; i < InternalSettings::EnumButtonOverrideColorsActiveButtonType::COUNT; i++) {
         m_internalSettings->setButtonOverrideColorsActive(
             i,
-            encodeColorOverrideTableColumn(static_cast<ConfigWidget *>(m_parent)->m_allCustomizableButtonsOrder.indexOf(static_cast<DecorationButtonType>(i)),
+            encodeColorOverrideTableColumn(static_cast<ConfigWidget *>(m_parent)->m_allCustomizableButtonsOrder.indexOf(buttonTypeFromKcfgColorIndex(i)),
                                            true,
                                            resetActive));
         m_internalSettings->setButtonOverrideColorsInactive(
             i,
-            encodeColorOverrideTableColumn(static_cast<ConfigWidget *>(m_parent)->m_allCustomizableButtonsOrder.indexOf(static_cast<DecorationButtonType>(i)),
+            encodeColorOverrideTableColumn(static_cast<ConfigWidget *>(m_parent)->m_allCustomizableButtonsOrder.indexOf(buttonTypeFromKcfgColorIndex(i)),
                                            false,
                                            resetInactive));
     }
@@ -818,10 +818,9 @@ void ButtonColors::updateChanged()
     if (!modified) {
         bool resetActive = !m_ui->buttonColorOverrideToggleActive->isChecked();
         for (int i = 0; i < InternalSettings::EnumButtonOverrideColorsActiveButtonType::COUNT; i++) {
-            if (encodeColorOverrideTableColumn(
-                    static_cast<ConfigWidget *>(m_parent)->m_allCustomizableButtonsOrder.indexOf(static_cast<DecorationButtonType>(i)),
-                    true,
-                    resetActive)
+            if (encodeColorOverrideTableColumn(static_cast<ConfigWidget *>(m_parent)->m_allCustomizableButtonsOrder.indexOf(buttonTypeFromKcfgColorIndex(i)),
+                                               true,
+                                               resetActive)
                 != m_internalSettings->buttonOverrideColorsActive(i).toUtf8()) {
                 modified = true;
                 break;
@@ -831,10 +830,9 @@ void ButtonColors::updateChanged()
     if (!modified) {
         bool resetInactive = !m_ui->buttonColorOverrideToggleInactive->isChecked();
         for (int i = 0; i < InternalSettings::EnumButtonOverrideColorsActiveButtonType::COUNT; i++) {
-            if (encodeColorOverrideTableColumn(
-                    static_cast<ConfigWidget *>(m_parent)->m_allCustomizableButtonsOrder.indexOf(static_cast<DecorationButtonType>(i)),
-                    false,
-                    resetInactive)
+            if (encodeColorOverrideTableColumn(static_cast<ConfigWidget *>(m_parent)->m_allCustomizableButtonsOrder.indexOf(buttonTypeFromKcfgColorIndex(i)),
+                                               false,
+                                               resetInactive)
                 != m_internalSettings->buttonOverrideColorsInactive(i).toUtf8()) {
                 modified = true;
                 break;

--- a/kdecoration/config/buttoncolors.h
+++ b/kdecoration/config/buttoncolors.h
@@ -179,6 +179,7 @@ private:
         {DecorationButtonType::OnAllDesktops, i18n("All desktops")},
         {DecorationButtonType::KeepBelow, i18n("Keep behind")},
         {DecorationButtonType::KeepAbove, i18n("Keep in front")},
+        {DecorationButtonType::ExcludeFromCapture, i18n("Exclude from capture")},
         {DecorationButtonType::ApplicationMenu, i18n("Application menu")},
         {DecorationButtonType::Menu, i18n("Window menu")},
     };

--- a/libbreezecommon/breeze.h
+++ b/libbreezecommon/breeze.h
@@ -108,9 +108,53 @@ enum class DecorationButtonType {
      * The Spacer button provides some space between buttons.
      */
     Spacer,
-
-    COUNT
+    /**
+     * The ExcludeFromCapture button toggles the DecoratedWindow's visibility
+     * for screen capture and displays the current exclusion state.
+     *
+     * By default this button is only visible when the window is excluded from capture,
+     * but it can be made always visible via settings.
+     **/
+    ExcludeFromCapture,
 };
+
+inline DecorationButtonType buttonTypeFromKcfgColorIndex(int index)
+{
+    static const QList<DecorationButtonType> kcfgIndexToButtonType{
+        DecorationButtonType::Menu,
+        DecorationButtonType::ApplicationMenu,
+        DecorationButtonType::OnAllDesktops,
+        DecorationButtonType::Minimize,
+        DecorationButtonType::Maximize,
+        DecorationButtonType::Close,
+        DecorationButtonType::ContextHelp,
+        DecorationButtonType::Shade,
+        DecorationButtonType::KeepBelow,
+        DecorationButtonType::KeepAbove,
+        DecorationButtonType::ExcludeFromCapture,
+    };
+    if (index < 0 || index >= kcfgIndexToButtonType.length())
+        return DecorationButtonType::Custom;
+    return kcfgIndexToButtonType[index];
+}
+
+inline int buttonTypeToKcfgColorIndex(DecorationButtonType type)
+{
+    static const QMap<DecorationButtonType, int> buttonTypeToKcfgIndex{
+        {DecorationButtonType::Menu, 0},
+        {DecorationButtonType::ApplicationMenu, 1},
+        {DecorationButtonType::OnAllDesktops, 2},
+        {DecorationButtonType::Minimize, 3},
+        {DecorationButtonType::Maximize, 4},
+        {DecorationButtonType::Close, 5},
+        {DecorationButtonType::ContextHelp, 6},
+        {DecorationButtonType::Shade, 7},
+        {DecorationButtonType::KeepBelow, 8},
+        {DecorationButtonType::KeepAbove, 9},
+        {DecorationButtonType::ExcludeFromCapture, 10},
+    };
+    return buttonTypeToKcfgIndex[type];
+}
 
 // list of keys used for window decoration exceptions
 static QStringList windecoExceptionKeys = {

--- a/libbreezecommon/breezesettingsdata.kcfg
+++ b/libbreezecommon/breezesettingsdata.kcfg
@@ -447,6 +447,7 @@
                 <value>Shade</value>
                 <value>KeepBelow</value>
                 <value>KeepAbove</value>
+                <value>ExcludeFromCapture</value>
             </values>
         </parameter>
     </entry>
@@ -464,6 +465,7 @@
                 <value>Shade</value>
                 <value>KeepBelow</value>
                 <value>KeepAbove</value>
+                <value>ExcludeFromCapture</value>
             </values>
         </parameter>
     </entry>

--- a/libbreezecommon/decorationbuttoncolors.cpp
+++ b/libbreezecommon/decorationbuttoncolors.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only OR LicenseRef-KDE-Accepted-GPL
  */
 #include "decorationbuttoncolors.h"
+#include "breeze.h"
 #include "colortools.h"
 #include <KColorUtils>
 #include <QJsonArray>
@@ -61,9 +62,11 @@ void DecorationButtonPalette::decodeButtonOverrideColors(const bool active)
     buttonOverrideColors.clear();
     buttonOverrideColorsPresent = false;
 
+    const int buttonType = buttonTypeToKcfgColorIndex(_buttonType);
+
     bool overrideButtonTypeValid = false;
     for (int i = 0; i < InternalSettings::EnumButtonOverrideColorsActiveButtonType::COUNT; i++) {
-        if (static_cast<int>(_buttonType) == i) {
+        if (buttonType == i) {
             overrideButtonTypeValid = true;
             break;
         }
@@ -72,8 +75,8 @@ void DecorationButtonPalette::decodeButtonOverrideColors(const bool active)
         return;
     }
 
-    QByteArray overrideColorsSetting = active ? _decorationSettings->buttonOverrideColorsActive(static_cast<int>(_buttonType)).toUtf8()
-                                              : _decorationSettings->buttonOverrideColorsInactive(static_cast<int>(_buttonType)).toUtf8();
+    QByteArray overrideColorsSetting =
+        active ? _decorationSettings->buttonOverrideColorsActive(buttonType).toUtf8() : _decorationSettings->buttonOverrideColorsInactive(buttonType).toUtf8();
     if (overrideColorsSetting.isEmpty()) {
         return;
     }

--- a/libbreezecommon/decorationbuttoncolors.h
+++ b/libbreezecommon/decorationbuttoncolors.h
@@ -31,6 +31,7 @@ const QList<DecorationButtonType> coloredWindowDecorationButtonTypes{
     DecorationButtonType::KeepBelow,
     DecorationButtonType::KeepAbove,
     DecorationButtonType::Custom,
+    DecorationButtonType::ExcludeFromCapture,
 };
 
 const QList<DecorationButtonType> coloredAppStyleDecorationButtonTypes{

--- a/libbreezecommon/renderdecorationbuttonicon.cpp
+++ b/libbreezecommon/renderdecorationbuttonicon.cpp
@@ -176,6 +176,10 @@ void RenderDecorationButtonIcon::renderIcon(DecorationButtonType type, bool chec
         renderContextHelpIcon();
         break;
 
+    case DecorationButtonType::ExcludeFromCapture:
+        renderExcludeFromCaptureIcon();
+        break;
+
     default:
         break;
     }

--- a/libbreezecommon/renderdecorationbuttonicon.h
+++ b/libbreezecommon/renderdecorationbuttonicon.h
@@ -115,6 +115,7 @@ protected:
     virtual void renderKeepInFrontIcon() = 0;
     virtual void renderApplicationMenuIcon() = 0;
     virtual void renderContextHelpIcon() = 0;
+    virtual void renderExcludeFromCaptureIcon() = 0;
 
     /**
      *@brief Multiplies the pen width by the bolding factor, and rounds it. Also returns whether the integer-rounded bold pen with is an even or odd number of

--- a/libbreezecommon/renderdecorationbuttonicon18by18.cpp
+++ b/libbreezecommon/renderdecorationbuttonicon18by18.cpp
@@ -1362,4 +1362,43 @@ void RenderDecorationButtonIcon18By18::renderContextHelpIcon()
         m_painter->drawEllipse(QRectF(8.25, 14.25, 1.5, 1.5));
 }
 
+void RenderDecorationButtonIcon18By18::renderExcludeFromCaptureIcon()
+{
+    QPen pen = m_painter->pen();
+    if ((!m_fromKstyle) && m_boldButtonIcons) {
+        // thicker pen in titlebar
+        pen.setWidthF(pen.widthF() * 1.6);
+    }
+
+    pen.setJoinStyle(Qt::RoundJoin);
+    m_painter->setPen(pen);
+
+    QPainterPath path;
+
+    // Fedora brim
+    path.moveTo(0.5, 8);
+    path.lineTo(17.5, 8);
+
+    // Fedora crown with center crease
+    path.moveTo(3, 7.5);
+    path.quadTo(3, 2, 6, 2);
+    path.cubicTo(7, 2, 8, 3, 9, 3.5);
+    path.cubicTo(10, 3, 11, 2, 12, 2);
+    path.quadTo(15, 2, 15, 7.5);
+    path.closeSubpath();
+
+    // Glasses
+    path.addEllipse(QRectF(1.5, 9.5, 6, 6));
+    path.addEllipse(QRectF(10.5, 9.5, 6, 6));
+    path.moveTo(7.5, 12.5);
+    path.lineTo(10.5, 12.5);
+    if (m_strokeToFilledPath) {
+        QPainterPathStroker stroker(m_painter->pen());
+        path = stroker.createStroke(path);
+
+        m_painter->setPen(Qt::NoPen);
+        m_painter->setBrush(pen.color());
+    }
+    m_painter->drawPath(path);
+}
 }

--- a/libbreezecommon/renderdecorationbuttonicon18by18.h
+++ b/libbreezecommon/renderdecorationbuttonicon18by18.h
@@ -37,6 +37,7 @@ protected:
     virtual void renderKeepInFrontIcon() override;
     virtual void renderApplicationMenuIcon() override;
     virtual void renderContextHelpIcon() override;
+    virtual void renderExcludeFromCaptureIcon() override;
 
     void renderCloseIconAtSquareMaximizeSize();
     std::pair<QRectF, qreal> renderSquareMaximizeIcon(bool returnSizeOnly = false, qreal cornerRelativePercent = 0.025, bool showArrows = false);

--- a/libbreezecommon/systemicontheme.cpp
+++ b/libbreezecommon/systemicontheme.cpp
@@ -100,6 +100,11 @@ void SystemIconTheme::systemIconNames(DecorationButtonType type, QString &system
         systemIconCheckedName = systemIconName;
         break;
 
+    case DecorationButtonType::ExcludeFromCapture:
+        systemIconName = isSystemIconNameAvailable(QStringLiteral("view-private-symbolic"), QStringLiteral("view-private"));
+        systemIconCheckedName = systemIconName;
+        break;
+
     default:
         break;
     }


### PR DESCRIPTION
Adds the exclude from capture button and allows theming it like other buttons. It acts like a checkable button when always shown & acts like any other button if not always shown.

I'm currently working on adding an integrated menu option to Klassy, but I figured I should separate-out & PR the exclude from capture button work first. I'm not much of a designer, so I 100% understand if the icon needs some changes.

# Pictures
To better capture it, all pictures are with the following icon color overrides (icon normal, icon hover, & icon pressed respectively):
<img width="307" height="295" alt="_Overrides" src="https://github.com/user-attachments/assets/84771e7f-3619-44d7-afd8-c496afa2ab5c" />

Theme | State    |Size| Picture
------| -----    |----|-------
Klasse|Unchecked<sup>†</sup>| 20 | <img width="118" height="36" alt="_20" src="https://github.com/user-attachments/assets/999ae5e3-4002-47cf-a4a7-2284ec166ea7" />
Klasse|Unchecked<sup>†</sup>| 48 | <img width="252" height="70" alt="_Fine" src="https://github.com/user-attachments/assets/b3acbeb9-9dad-439c-854e-4b954a1fbc6b" />
Klasse|Unchecked<sup>†</sup> + Bolded|48| <img width="246" height="64" alt="_Bolded" src="https://github.com/user-attachments/assets/ea205cb4-713c-4122-b86d-643d4cb35da3" />
Klasse|Checked   | 48 | <img width="252" height="70" alt="_Checked" src="https://github.com/user-attachments/assets/9f75a2c2-90c1-4e56-b2f4-ce0e264fa3a0" />
System (candy-icons)|Unchecked<sup>†</sup>| 48 | <img width="257" height="75" alt="_System" src="https://github.com/user-attachments/assets/f196e506-3e3f-4411-818d-148bef286bd3" />


† Unchecked in this case means either:
* Always show exclude from capture is true & the button is not checked
* Always show exclude from capture is false & the window is excluded from capture

